### PR TITLE
New recipe to add Jenkins cli jar in jars directory

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -22,6 +22,7 @@ suites:
       - recipe[jenkins::temurin]
       - recipe[jenkins::jenkins]
       - recipe[jenkins::plugin_manager]
+      - recipe[jenkins::cli]
     verifier:
       inspec_tests:
         - test/integration/default

--- a/recipes/cli.rb
+++ b/recipes/cli.rb
@@ -1,0 +1,4 @@
+remote_file '/usr/local/jenkins/jars/jenkins-cli.jar' do
+  source 'http://localhost:8080/jnlpJars/jenkins-cli.jar'
+  action :create
+end


### PR DESCRIPTION
### Description
As stated above, this PR adds a recipe that downloads the Jenkins cli jar file from the running jenkins instance and stores it along side the other jars in `/usr/local/jenkins/jars`. 
