### PR TITLE
Fix `java_opts` path and  map it as attribute

### DIFF
--- a/attributes/jenkins.rb
+++ b/attributes/jenkins.rb
@@ -1,1 +1,2 @@
 default["jenkins"]["lts"] = true
+default["jenkins"]["master"]["java_opts"] = '' 

--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -30,7 +30,9 @@ apt_update "jenkins" do
   action :nothing
 end
 
-if node['jenkins']['java_opts']
+java_opts =  node['jenkins']['master']['java_opts']
+
+if java_opts
   directory '/etc/systemd/system/jenkins.service.d'
   template '/etc/systemd/system/jenkins.service.d/override.conf' do
     source 'jenkins-service-override.conf.erb'


### PR DESCRIPTION
### Description

Follow-up to #2 adds the correct path for the `java_opts` attribute and adds a default value on attributes file. 