### PR TITLE
Remove custom java_opts attribute

### DIFF
--- a/attributes/jenkins.rb
+++ b/attributes/jenkins.rb
@@ -1,2 +1,1 @@
 default["jenkins"]["lts"] = true
-default["jenkins"]["master"]["java_opts"] = '' 


### PR DESCRIPTION
I think the presence of this is replacing the default attribute being passed from another recipe. 

Removing it to reduce the scope of things that might cause this.