### PR TITLE
Fixes for handling Jenkins Java options.

### DIFF
--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -31,6 +31,14 @@ apt_update "jenkins" do
 end
 
 if node.exist?('jenkins', 'master', 'java_opts')
+  execute "systemctl-daemon-reload" do
+    command "systemctl daemon-reload"
+    action :nothing
+  end
+
+  service "jenkins" do
+    action :nothing
+  end
 
   java_opts =  node['jenkins']['master']['java_opts']
   directory '/etc/systemd/system/jenkins.service.d'
@@ -42,6 +50,8 @@ if node.exist?('jenkins', 'master', 'java_opts')
       java_opts: java_opts
     ]
   end
+  notifies :run, "execute[systemctl-daemon-reload]", :immediately
+  notifies :restart, "service[jenkins]", :delayed
 end
 
 package "jenkins"

--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -30,9 +30,9 @@ apt_update "jenkins" do
   action :nothing
 end
 
-java_opts =  node['jenkins']['master']['java_opts']
+if node.exist?('jenkins', 'master', 'java_opts')
 
-if java_opts
+  java_opts =  node['jenkins']['master']['java_opts']
   directory '/etc/systemd/system/jenkins.service.d'
   template '/etc/systemd/system/jenkins.service.d/override.conf' do
     source 'jenkins-service-override.conf.erb'


### PR DESCRIPTION
Test kitchen was failing because when the nested attribute is not specified there's an error accessing it.

systemd overrides don't take effect until the service definition is reloaded (triggered by `systemctl daemon-reload` and the service is restarted.

