### PR TITLE
Add systemd override configuration for defining JAVA_OPTS.

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -27,3 +27,15 @@ suites:
       inspec_tests:
         - test/integration/default
     attributes:
+  - name: custom_java_opts
+    run_list:
+      - recipe[jenkins::temurin]
+      - recipe[jenkins::jenkins]
+      - recipe[jenkins::plugin_manager]
+      - recipe[jenkins::cli]
+    verifier:
+      inspec_tests:
+        - test/integration/default
+    attributes:
+      jenkins:
+        jenkins_java_opts: -Djava.awt.headless=true -Djenkins.install.runSetupWizard=true

--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -30,7 +30,29 @@ apt_update "jenkins" do
   action :nothing
 end
 
+# Migrate from attributes used by sous-chefs/jenkins
+# The expected attributes have been changed but in order to remain compatible
+# with configurations from the prior cookbook a warning is being added if the
+# old attributes are set and differ from the new ones.
 if node.exist?('jenkins', 'master', 'java_opts')
+  if !node.exist?('jenkins', 'jenkins_java_opts')
+      Chef::Log.warn(
+        "The attribute `node['jenkins']['master']['java_opts']` is now `node['jenkins']['jenkins_java_opts']`. " +
+        "Support for the previous attribute may be removed in a future release of this cookbook. " +
+        "Replacing the `node['jenkins']['master']['java_opts']` attribute with `node['jenkins']['jenkins_java_opts']` is recommended."
+      )
+      node.default['jenkins']['jenkins_java_opts'] = node['jenkins']['master']['java_opts']
+  elsif node['jenkins']['jenkins_java_opts'] != node['jenkins']['master']['java_opts']
+      Chef::Log.warn(
+        "Both `node['jenkins']['master']['java_opts']` and `node['jenkins']['jenkins_java_opts']` are defined but differ. " +
+        "The `node['jenkins']['jenkins_java_opts']` attribute will be used. " +
+        "Support for the previous attribute may be removed in a future release of this cookbook. " +
+        "Removing the `node['jenkins']['master']['java_opts']` attribute is recommended."
+      )
+  end
+end
+
+if node.exist?('jenkins', 'jenkins_java_opts')
   execute "systemctl-daemon-reload" do
     command "systemctl daemon-reload"
     action :nothing
@@ -40,7 +62,7 @@ if node.exist?('jenkins', 'master', 'java_opts')
     action :nothing
   end
 
-  java_opts =  node['jenkins']['master']['java_opts']
+  java_opts =  node['jenkins']['jenkins_java_opts']
   directory '/etc/systemd/system/jenkins.service.d'
   template '/etc/systemd/system/jenkins.service.d/override.conf' do
     source 'jenkins-service-override.conf.erb'

--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -31,16 +31,24 @@ apt_update "jenkins" do
 end
 
 if node.exist?('jenkins', 'master', 'java_opts')
+  execute "systemctl-daemon-reload" do
+    command "systemctl daemon-reload"
+    action :nothing
+  end
+
+  service "jenkins" do
+    action :nothing
+  end
 
   java_opts =  node['jenkins']['master']['java_opts']
   directory '/etc/systemd/system/jenkins.service.d'
   template '/etc/systemd/system/jenkins.service.d/override.conf' do
     source 'jenkins-service-override.conf.erb'
-    owner 'jenkins'
-    group 'jenkins'
     variables Hash[
       java_opts: java_opts
     ]
+    notifies :run, "execute[systemctl-daemon-reload]", :immediately
+    notifies :restart, "service[jenkins]", :delayed
   end
 end
 

--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -30,9 +30,9 @@ apt_update "jenkins" do
   action :nothing
 end
 
-java_opts =  node['jenkins']['master']['java_opts']
+if node.exist?('jenkins', 'master', 'java_opts')
 
-if java_opts
+  java_opts =  node['jenkins']['master']['java_opts']
   directory '/etc/systemd/system/jenkins.service.d'
   template '/etc/systemd/system/jenkins.service.d/override.conf' do
     source 'jenkins-service-override.conf.erb'

--- a/templates/jenkins-service-override.conf.erb
+++ b/templates/jenkins-service-override.conf.erb
@@ -1,1 +1,2 @@
-Environment="JAVA_OPTS='<%= java_opts %>'"
+[Service]
+Environment="JAVA_OPTS='<%= @java_opts %>'"


### PR DESCRIPTION
With the Jenkins systemd service, configuration of things like arguments passed to the JVM invocation need to be done with systemd overrides.

There are more potential configuration options but I think it makes the most sense to add them only as they are used.

What is configurable and how is discoverable by reading the distributed `/usr/bin/jenkins` launch script and the systemd service unit shown when running `systemctl edit jenkins.service`.