### PR TITLE
Run GPG command without interactivity or tty.

### DIFF
--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -1,5 +1,5 @@
 execute 'jenkins-dearmor' do
-  command "gpg -o /etc/apt/keyrings/jenkins.gpg --dearmor < /tmp/jenkins.asc"
+  command "gpg --batch --no-tty -o /etc/apt/keyrings/jenkins.gpg --dearmor < /tmp/jenkins.asc"
   action :nothing
 end
 


### PR DESCRIPTION
This is correct anyway but it was causing errors using kitchen-dokken.