### PR TITLE
Fixes for dokken test kitchen provisioner.

### DIFF
--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -13,7 +13,6 @@ provisioner:
   name: dokken
   product_name: cinc_solo
   chef_binary: /opt/cinc/bin/cinc-solo
-  #chef_options: "-Etest"
   chef_log_level: debug
   chef_output_format: doc
 

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -23,3 +23,5 @@ platforms:
       pid_one_command: /bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update
+        - ENV LANG C
+        - ENV LC_ALL C

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -6,8 +6,6 @@ provisioner:
   name: chef_zero
   product_name: cinc
   product_version: 17
-  solo_rb:
-    environment: test
 
 
 verifier:

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -15,7 +15,7 @@ platforms:
   - name: ubuntu-24.04
 
 suites:
-  - name: default
+  - name: jenkins-default
     run_list:
       - recipe[jenkins::temurin]
       - recipe[jenkins::jenkins]
@@ -25,7 +25,8 @@ suites:
       inspec_tests:
         - test/integration/default
     attributes:
-  - name: custom_java_opts
+
+  - name: jenkins-custom_java_opts
     run_list:
       - recipe[jenkins::temurin]
       - recipe[jenkins::jenkins]


### PR DESCRIPTION
These changes support running test with kitchen-dokken, which is the best way we've found for running them in GitHub Actions CI.