### PR TITLE
Enable and start Jenkins service from recipe.

### DIFF
--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -52,13 +52,11 @@ if node.exist?('jenkins', 'master', 'java_opts')
   end
 end
 
+package "jenkins"
+
 if node.exist?('jenkins', 'jenkins_java_opts')
   execute "systemctl-daemon-reload" do
     command "systemctl daemon-reload"
-    action :nothing
-  end
-
-  service "jenkins" do
     action :nothing
   end
 
@@ -74,4 +72,6 @@ if node.exist?('jenkins', 'jenkins_java_opts')
   end
 end
 
-package "jenkins"
+service 'jenkins' do
+  action [:enable, :start]
+end


### PR DESCRIPTION
This recipe should conclude with the Jenkins service started. The configuration of the systemd service overrides cannot succeed until the package is installed because the overrides won't register without the base service. The CLI recipe also needs the Jenkins service started in order to fetch the CLI jar.