### PR TITLE
Compare jenkins version to install and prevent downgrade

### DIFF
--- a/attributes/jenkins.rb
+++ b/attributes/jenkins.rb
@@ -1,1 +1,7 @@
 default["jenkins"]["lts"] = true
+
+# Pin the exact Jenkins package version to install/upgrade to. Leave unset to
+# always install whatever is newest in the apt repo. Jenkins does not support
+# downgrades, so jenkins::jenkins will refuse to converge if this is set lower
+# than the version already installed on the node.
+default["jenkins"]["master"]["version"] = nil

--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -42,7 +42,33 @@ if node.exist?('jenkins', 'master', 'java_opts')
   end
 end
 
-package "jenkins"
+# Jenkins downgrade protection
+#
+# apt will happily install whatever version is pinned in
+# node['jenkins']['master']['version'] (or the newest available, if unset).
+# Jenkins does not support downgrades, and some configurations continue
+# running even after a downgrade attempt corrupts the installation. Compare
+# against the version Ohai detects installed (dpkg's version string, with any
+# Debian revision suffix stripped) and abort rather than risk a downgrade.
+installed_version = node.dig('packages', 'jenkins', 'version')
+pinned_version = node['jenkins']['master']['version']
+
+if installed_version && pinned_version
+  normalize = ->(v) { Gem::Version.new(v.split('-').first) }
+  if normalize.call(pinned_version) < normalize.call(installed_version)
+    Chef::Log.fatal(
+      "Jenkins #{installed_version} is already installed, which is newer than the pinned " +
+      "node['jenkins']['master']['version'] = #{pinned_version}. Jenkins does not support " +
+      "downgrades. Set node['jenkins']['master']['version'] to #{installed_version} or newer " +
+      "before this cookbook can continue."
+    )
+    raise
+  end
+end
+
+package "jenkins" do
+  version pinned_version if pinned_version
+end
 
 if node.exist?('jenkins', 'jenkins_java_opts')
   execute "systemctl-daemon-reload" do


### PR DESCRIPTION
# Description

Downstream cookbooks (ros_buildfarm, osrfbuild) each had to hand-roll their own downgrade guard by shelling out to dpkg -s jenkins and stashing state in node.run_state. This moves that protection into the cookbook that actually owns the package "jenkins" resource, using Ohai's built-in packages plugin instead of a shell-out, and makes version pinning a supported, general-purpose feature rather than a one-off patch tied to the sysvinit -> systemd migration.

Note: Using `Gem::Version` looks a bit weird, but it's a way to don't compare the versions manually, but relying on a stdlib two compare the dotted versions strings correctly, shipped with Ruby itself

## Changes:
- Adds `node['jenkins']['master']['version']` to pin the exact Jenkins package version installed/upgraded to. Leaving it unset preserves current behavior (always install newest).
- `jenkins::jenkins` now compares the pinned version against the version Ohai detects already installed (`node['packages']['jenkins']['version']`) and aborts with a fatal error rather than letting apt downgrade Jenkins, which it does not support and which can corrupt an already-configured instance.