### PR TITLE
Add `TimeoutStartSec` to Jenkins service

### DIFF
--- a/attributes/jenkins.rb
+++ b/attributes/jenkins.rb
@@ -5,7 +5,3 @@ default["jenkins"]["lts"] = true
 # downgrades, so jenkins::jenkins will refuse to converge if this is set lower
 # than the version already installed on the node.
 default["jenkins"]["master"]["version"] = nil
-
-# Defer the initial Jenkins start to the end of the client run, so a later
-# recipe (e.g. ros_buildfarm::plugins) can fix plugins before it boots.
-default["jenkins"]["delay_start"] = false

--- a/attributes/jenkins.rb
+++ b/attributes/jenkins.rb
@@ -5,3 +5,7 @@ default["jenkins"]["lts"] = true
 # downgrades, so jenkins::jenkins will refuse to converge if this is set lower
 # than the version already installed on the node.
 default["jenkins"]["master"]["version"] = nil
+
+# Defer the initial Jenkins start to the end of the client run, so a later
+# recipe (e.g. ros_buildfarm::plugins) can fix plugins before it boots.
+default["jenkins"]["delay_start"] = false

--- a/templates/jenkins-service-override.conf.erb
+++ b/templates/jenkins-service-override.conf.erb
@@ -1,2 +1,3 @@
 [Service]
 Environment="JAVA_OPTS='<%= @java_opts %>'"
+TimeoutStartSec=1200


### PR DESCRIPTION
# Description

Add TimeoutStartSec

## Changes
- `templates/jenkins-service-override.conf.erb`: add `TimeoutStartSec=1200` to the systemd override, so systemd doesn't kill Jenkins mid-boot on a slow first start (e.g. after a large plugin re-pin or JDK bump) before it has a chance to come up.

## Considerations

This change is needed to make the multi-LTS Jenkins core/plugin migration (2.492.2 → 2.555.3) in the companion `ros_buildfarm` PR converge cleanly:
- Without the longer `TimeoutStartSec`, systemd's default start timeout can kill Jenkins before it finishes booting when startup is unusually slow (large plugin set, JDK version change).