### PR TITLE
Remove expectation of Jenkins to be running for cli recipe

### DIFF
--- a/recipes/cli.rb
+++ b/recipes/cli.rb
@@ -1,8 +1,18 @@
+# Jenkins must actually be serving requests for this to succeed. If it's
+# already running (e.g. a re-converge), download right away; otherwise wait
+# for service[jenkins] to (re)start it before trying.
+jenkins_running = system('systemctl is-active --quiet jenkins')
+
 remote_file '/usr/local/jenkins/jars/jenkins-cli.jar' do
   source 'http://localhost:8080/jnlpJars/jenkins-cli.jar'
-  action :nothing
-  subscribes :create, 'service[jenkins]'
   # Add retry logic since it might take a bit for Jenkins to be operational
   retries 3
   retry_delay 5
+
+  if jenkins_running
+    action :create_if_missing
+  else
+    action :nothing
+    subscribes :create, 'service[jenkins]', :delayed
+  end
 end

--- a/recipes/cli.rb
+++ b/recipes/cli.rb
@@ -1,4 +1,8 @@
 remote_file '/usr/local/jenkins/jars/jenkins-cli.jar' do
   source 'http://localhost:8080/jnlpJars/jenkins-cli.jar'
-  action :create
+  action :nothing
+  subscribes :create, 'service[jenkins]'
+  # Add retry logic since it might take a bit for Jenkins to be operational
+  retries 3
+  retry_delay 5
 end

--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -89,5 +89,6 @@ if node.exist?('jenkins', 'jenkins_java_opts')
 end
 
 service 'jenkins' do
-  action [:enable, :start]
+  action [:enable] 
+  delayed_action :start
 end


### PR DESCRIPTION
In #16 some edge cases appeared that prompted for a `:delayed` start of the Jenkins recipe. 
That broke the assumptions of the `cli.rb` recipe added in #1 since it expected Jenkins to be operational to download the needed jar. 

This PR does two things: 

- Modifies the cli recipe to be more resilient when Jenkins is not running by subscribing the creation to the service state. Additionally ensure reconverge are able to self-heal the cli recipe if the file got removed. 
- Add `:delayed` to the jenkins service start to avoid preemptively starting the service and allow for all configs to be present before starting. 