### PR TITLE
Add test suite for the recipes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         suite:
           - 'default'
-          - 'pinned-version'
+          - 'jenkins-pinned'
         chef_version:
           - '19'
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
       matrix:
         suite:
           - 'default'
+          - 'pinned-version'
         chef_version:
           - '19'
       fail-fast: false

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -29,11 +29,12 @@ suites:
     attributes:
   - name: jenkins-pinned
     run_list:
+      - recipe[jenkins::temurin]
       - recipe[jenkins::jenkins]
     verifier:
       inspec_tests:
         - test/integration/pinned-version
     attributes:
-      jenkins: 
+      jenkins:
         master:
           version: 2.401.3

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -17,7 +17,7 @@ platforms:
   - name: ubuntu-24.04
 
 suites:
-  - name: default
+  - name: jenkins-default
     run_list:
       - recipe[jenkins::temurin]
       - recipe[jenkins::jenkins]
@@ -27,3 +27,13 @@ suites:
       inspec_tests:
         - test/integration/default
     attributes:
+  - name: jenkins-pinned
+    run_list:
+      - recipe[jenkins::jenkins]
+    verifier:
+      inspec_tests:
+        - test/integration/pinned-version
+    attributes:
+      jenkins: 
+        master:
+          version: 2.401.3

--- a/test/integration/default/cli_test.rb
+++ b/test/integration/default/cli_test.rb
@@ -1,0 +1,6 @@
+# Chef InSpec test for recipe jenkins::cli
+
+describe file('/usr/local/jenkins/jars/jenkins-cli.jar') do
+  it { should exist }
+  it { should be_file }
+end

--- a/test/integration/default/default_test.rb
+++ b/test/integration/default/default_test.rb
@@ -1,16 +1,11 @@
 # Chef InSpec test for recipe jenkins::default
-
+#
 # The Chef InSpec reference, with examples and extensive documentation, can be
 # found at https://docs.chef.io/inspec/resources/
 
-unless os.windows?
-  # This is an example test, replace with your own test.
-  describe user('root'), :skip do
-    it { should exist }
-  end
-end
-
-# This is an example test, replace it with your own test.
-describe port(80), :skip do
-  it { should_not be_listening }
+# Jenkins should be up and serving requests by the end of the suite's run
+# list (jenkins::jenkins enables/starts the service, jenkins::cli waits for
+# it to come up before downloading the CLI jar).
+describe port(8080) do
+  it { should be_listening }
 end

--- a/test/integration/default/jenkins_test.rb
+++ b/test/integration/default/jenkins_test.rb
@@ -1,0 +1,23 @@
+# Chef InSpec test for recipe jenkins::jenkins
+
+describe file('/etc/apt/keyrings/jenkins-keyring.asc') do
+  it { should exist }
+  its('mode') { should cmp '0644' }
+  its('owner') { should eq 'root' }
+end
+
+describe file('/etc/apt/sources.list.d/jenkins.list') do
+  it { should exist }
+  # node['jenkins']['lts'] defaults to true, which points at the
+  # debian-stable repository.
+  its('content') { should match(%r{https://pkg\.jenkins\.io/debian-stable binary/}) }
+end
+
+describe package('jenkins') do
+  it { should be_installed }
+end
+
+describe service('jenkins') do
+  it { should be_enabled }
+  it { should be_running }
+end

--- a/test/integration/default/plugin_manager_test.rb
+++ b/test/integration/default/plugin_manager_test.rb
@@ -1,0 +1,15 @@
+# Chef InSpec test for recipe jenkins::plugin_manager
+
+describe directory('/usr/local/jenkins/jars') do
+  it { should exist }
+  its('owner') { should eq 'jenkins' }
+  its('group') { should eq 'jenkins' }
+end
+
+describe file('/usr/local/jenkins/jars/jenkins-plugin-manager.jar') do
+  it { should exist }
+  it { should be_file }
+  its('owner') { should eq 'jenkins' }
+  its('group') { should eq 'jenkins' }
+  its('mode') { should cmp '0644' }
+end

--- a/test/integration/default/temurin_test.rb
+++ b/test/integration/default/temurin_test.rb
@@ -1,0 +1,15 @@
+# Chef InSpec test for recipe jenkins::temurin
+
+describe file('/etc/apt/keyrings/adoptium.gpg') do
+  it { should exist }
+end
+
+describe file('/etc/apt/sources.list.d/adoptium.sources') do
+  it { should exist }
+  its('content') { should match(%r{URIs: https://packages\.adoptium\.net/artifactory/deb}) }
+  its('content') { should match(%r{Signed-By: /etc/apt/keyrings/adoptium\.gpg}) }
+end
+
+describe package('temurin-21-jdk') do
+  it { should be_installed }
+end

--- a/test/integration/pinned-version/jenkins_test.rb
+++ b/test/integration/pinned-version/jenkins_test.rb
@@ -1,0 +1,13 @@
+# Chef InSpec test for recipe jenkins::jenkins with
+# node['jenkins']['master']['version'] pinned to a specific, older release.
+#
+# Covers the version-pinning branch of the `package` resource, which is
+# otherwise untested by the `default` suite (which always installs
+# whatever is newest). This intentionally installs an old release, so it
+# only checks that the exact pinned version landed -- it does not assert
+# that the (out of date) Jenkins service comes up cleanly under a newer JDK.
+
+describe package('jenkins') do
+  it { should be_installed }
+  its('version') { should cmp '2.401.3' }
+end


### PR DESCRIPTION
### Description
Now that there is CI on this repository this PR adds basic smoke tests for the recipes. 
It would be good to check some of the tests on the original sous-chef repository and see if we can import some here. 

### Use of generative AI
This work was Assisted-by: Claude Sonnet 5 and reviewed before being commited