### PR TITLE
Remove `JAVA_OPTS` single quotes

### DIFF
--- a/templates/jenkins-service-override.conf.erb
+++ b/templates/jenkins-service-override.conf.erb
@@ -1,3 +1,3 @@
 [Service]
-Environment="JAVA_OPTS='<%= @java_opts %>'"
+Environment="JAVA_OPTS=<%= @java_opts %>"
 TimeoutStartSec=1200


### PR DESCRIPTION
Error in production reported in https://github.com/osrf/infrastructure-private/issues/84#issuecomment-5166096587

# Description

The `jenkins-service-override.conf.erb` template double-quotes the systemd `Environment=` assignment (correct, since `java_opts` values contain spaces) but also wraps the value itself in single quotes. `systemd`'s unit-file parser doesn't treat those inner single quotes as a second quoting layer, they become literal characters in `JAVA_OPTS`, corrupting argument boundaries by the time `java` sees them. With a single-flag `java_opts` (e.g. staging) this went unnoticed; with a real multi-flag production value it broke Jenkins outright:

```
    Unrecognized option: -server -Djava.awt.headless=true ... -Xms10g
```

## Changes
- `templates/jenkins-service-override.conf.erb`: drop the redundant inner single quotes around `<%= @java_opts %>`.

## Considerations

### Why this wasn't caught earlier
Staging's `java_opts` (`-Djenkins.install.runSetupWizard=false`) is a single token with no embedded spaces, so the same bug produced a harmlessly mangled but still single-token value there. It only surfaces with a multi-flag `java_opts`, which only production environments set.

It might be worth to restore the `JAVA_OPTS` test to handle this edge case